### PR TITLE
Add ambience switcher action plugin

### DIFF
--- a/src/bin/daemon/daemon.pro
+++ b/src/bin/daemon/daemon.pro
@@ -12,6 +12,7 @@ LIBS += -L../../plugins/debug -lphonebotdebug \
     -L../../plugins/profile -lphonebotprofile \
     -L../../plugins/time -lphonebottime \
     -L../../plugins/connman -lphonebotconnman \
+    -L../../plugins/ambience -lphonebotambience \
     -L../../lib/nemomw -lnemomw \
     -L../../lib/daemon -lphonebotdaemon \
     -L../../lib/meta -lphonebotmeta \

--- a/src/bin/harbour/harbour.pro
+++ b/src/bin/harbour/harbour.pro
@@ -20,6 +20,7 @@ LIBS += -L../../plugins/debug -lphonebotdebug \
     -L../../plugins/profile -lphonebotprofile \
     -L../../plugins/time -lphonebottime \
     -L../../plugins/connman -lphonebotconnman \
+    -L../../plugins/ambience -lphonebotambience \
     -L../../lib/nemomw -lnemomw \
     -L../../lib/config -lphonebotconfig \
     -L../../lib/daemon -lphonebotdaemon \

--- a/src/bin/harbour/main.cpp
+++ b/src/bin/harbour/main.cpp
@@ -52,6 +52,7 @@ Q_IMPORT_PLUGIN(PhoneBotDebugPlugin)
 Q_IMPORT_PLUGIN(PhoneBotProfilePlugin)
 Q_IMPORT_PLUGIN(PhoneBotTimePlugin)
 Q_IMPORT_PLUGIN(PhoneBotConnmanPlugin)
+Q_IMPORT_PLUGIN(PhoneBotAmbiencePlugin)
 
 static const char *REASON = "Cannot be created";
 

--- a/src/plugins/ambience/ambience.pro
+++ b/src/plugins/ambience/ambience.pro
@@ -1,0 +1,14 @@
+TEMPLATE = lib
+TARGET = phonebotambience
+QT = core dbus
+
+INCLUDEPATH += ../../lib/core \
+    ../../lib/meta \
+    ../../lib/nemomw
+
+CONFIG += plugin static
+
+HEADERS = ambienceaction.h
+
+SOURCES = plugin.cpp \
+    ambienceaction.cpp

--- a/src/plugins/ambience/ambienceaction.cpp
+++ b/src/plugins/ambience/ambienceaction.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2015 Zeta Sagittarii <zeta@sagittarii.fr>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * The names of its contributors may not be used to endorse or promote
+ *     products derived from this software without specific prior written
+ *     permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "ambienceaction.h"
+#include <action_p.h>
+#include <choicemodel.h>
+#include <QtDBus/QDBusConnection>
+#include <QtDBus/QDBusInterface>
+
+static const char *DBUS_SERVICE = "com.jolla.ambienced";
+static const char *DBUS_PATH = "/com/jolla/ambienced";
+static const char *DBUS_INTERFACE = "com.jolla.ambienced";
+static const char *DBUS_METHOD_NAME = "setAmbience";
+
+class AmbienceActionPrivate: public ActionPrivate
+{
+public:
+    explicit AmbienceActionPrivate(Action *q);
+
+    bool setActiveAmbience(QString ambience);
+
+    QString ambience;
+};
+
+AmbienceActionPrivate::AmbienceActionPrivate(Action *q)
+    : ActionPrivate(q)
+{
+}
+
+bool AmbienceActionPrivate::setActiveAmbience(QString ambience)
+{
+    QDBusConnection connection = QDBusConnection::sessionBus();
+
+    QDBusInterface interface (DBUS_SERVICE, DBUS_PATH, DBUS_INTERFACE, connection);
+
+    // Call the ambience change method, with the path of the desired ambience (format = "file:///xxxxx")
+    QDBusMessage result = interface.call(DBUS_METHOD_NAME, ambience);
+
+    if (result.type() == QDBusMessage::ErrorMessage)
+    {
+        qDebug() << __FUNCTION__ << "result.type() == QDBusMessage::ErrorMessage";
+        return false;
+    }
+
+    return true;
+
+}
+
+AmbienceAction::AmbienceAction(QObject *parent) :
+    Action(*(new AmbienceActionPrivate(this)), parent)
+{
+}
+
+AmbienceAction::~AmbienceAction()
+{
+}
+
+QString AmbienceAction::ambience() const
+{
+    Q_D(const AmbienceAction);
+    return d->ambience;
+}
+
+void AmbienceAction::setAmbience(const QString &ambience)
+{
+    Q_D(AmbienceAction);
+    if (d->ambience != ambience)
+    {
+        d->ambience = ambience;
+        emit ambienceChanged();
+    }
+}
+
+bool AmbienceAction::execute(Rule *rule)
+{
+    Q_D(AmbienceAction);
+    Q_UNUSED(rule);
+
+    return d->setActiveAmbience(d->ambience);
+}

--- a/src/plugins/ambience/ambienceaction.h
+++ b/src/plugins/ambience/ambienceaction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Lucien XU <sfietkonstantin@free.fr>
+ * Copyright (C) 2015 Zeta Sagittarii <zeta@sagittarii.fr>
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -29,26 +29,28 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-#include <QtCore/QCoreApplication>
-#include <QtCore/QtPlugin>
-#include "enginemanager.h"
+#ifndef AMBIANCEACTION_H
+#define AMBIANCEACTION_H
 
-Q_IMPORT_PLUGIN(PhoneBotDebugPlugin)
-Q_IMPORT_PLUGIN(PhoneBotProfilePlugin)
-Q_IMPORT_PLUGIN(PhoneBotTimePlugin)
-Q_IMPORT_PLUGIN(PhoneBotConnmanPlugin)
-Q_IMPORT_PLUGIN(PhoneBotAmbiencePlugin)
+#include <action.h>
+#include <abstractmetadata.h>
 
-int main(int argc, char **argv)
+class AmbienceActionPrivate;
+class AmbienceAction : public Action
 {
-    QCoreApplication app (argc, argv);
-    app.setOrganizationName("phonebot");
-    app.setApplicationName("phonebotd");
+    Q_OBJECT
+    Q_PROPERTY(QString ambience READ ambience WRITE setAmbience NOTIFY ambienceChanged)
 
-    EngineManager manager;
-    manager.reloadEngine();
+public:
+    explicit AmbienceAction(QObject *parent = 0);
+    virtual ~AmbienceAction();
+    QString ambience() const;
+    void setAmbience(const QString &ambience);
+    bool execute(Rule *rule);
+Q_SIGNALS:
+    void ambienceChanged();
+private:
+    Q_DECLARE_PRIVATE(AmbienceAction)
+};
 
-    QObject::connect(&app, &QCoreApplication::aboutToQuit, &manager, &EngineManager::stop);
-
-    return app.exec();
-}
+#endif // AMBIANCEACTION_H

--- a/src/plugins/ambience/plugin.cpp
+++ b/src/plugins/ambience/plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Lucien XU <sfietkonstantin@free.fr>
+ * Copyright (C) 2015 Zeta Sagittarii <zeta@sagittarii.fr>
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -29,26 +29,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-#include <QtCore/QCoreApplication>
-#include <QtCore/QtPlugin>
-#include "enginemanager.h"
+#include <phonebotextensionplugin.h>
+#include <QtQml/qqml.h>
+#include "ambienceaction.h"
 
-Q_IMPORT_PLUGIN(PhoneBotDebugPlugin)
-Q_IMPORT_PLUGIN(PhoneBotProfilePlugin)
-Q_IMPORT_PLUGIN(PhoneBotTimePlugin)
-Q_IMPORT_PLUGIN(PhoneBotConnmanPlugin)
-Q_IMPORT_PLUGIN(PhoneBotAmbiencePlugin)
-
-int main(int argc, char **argv)
+class PhoneBotAmbiencePlugin: public PhoneBotExtensionPlugin
 {
-    QCoreApplication app (argc, argv);
-    app.setOrganizationName("phonebot");
-    app.setApplicationName("phonebotd");
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.SfietKonstantin.phonebot.PhoneBotExtensionInterface")
+public:
+    void registerTypes()
+    {
+        qmlRegisterType<AmbienceAction>("org.SfietKonstantin.phonebot.ambience", 1, 0, "AmbienceAction");
+    }
+};
 
-    EngineManager manager;
-    manager.reloadEngine();
-
-    QObject::connect(&app, &QCoreApplication::aboutToQuit, &manager, &EngineManager::stop);
-
-    return app.exec();
-}
+#include "plugin.moc"

--- a/src/plugins/plugins.pro
+++ b/src/plugins/plugins.pro
@@ -1,2 +1,2 @@
 TEMPLATE = subdirs
-SUBDIRS = debug profile time connman
+SUBDIRS = debug profile time connman ambience


### PR DESCRIPTION
Here is a first version of the ambience switcher plugin, based on a copy of the profile switcher code, as shown here : http://talk.maemo.org/showpost.php?p=1454090&postcount=30

Limitations so far are that the ambiances path/name are hardcoded in the user interface, but they can be changed manually in the rule.qml file if needed.

Feels free to let me know of any change needed so that it fits with the rest of phonebot's code.

Thanks !
