### PR TITLE
add static notification plugin

### DIFF
--- a/src/bin/daemon/daemon.pro
+++ b/src/bin/daemon/daemon.pro
@@ -13,6 +13,7 @@ LIBS += -L../../plugins/debug -lphonebotdebug \
     -L../../plugins/time -lphonebottime \
     -L../../plugins/connman -lphonebotconnman \
     -L../../plugins/ambience -lphonebotambience \
+    -L../../plugins/notification -lphonebotnotification \
     -L../../lib/nemomw -lnemomw \
     -L../../lib/daemon -lphonebotdaemon \
     -L../../lib/meta -lphonebotmeta \

--- a/src/bin/harbour/harbour.pro
+++ b/src/bin/harbour/harbour.pro
@@ -21,6 +21,7 @@ LIBS += -L../../plugins/debug -lphonebotdebug \
     -L../../plugins/time -lphonebottime \
     -L../../plugins/connman -lphonebotconnman \
     -L../../plugins/ambience -lphonebotambience \
+    -L../../plugins/notification -lphonebotnotification \
     -L../../lib/nemomw -lnemomw \
     -L../../lib/config -lphonebotconfig \
     -L../../lib/daemon -lphonebotdaemon \

--- a/src/bin/harbour/main.cpp
+++ b/src/bin/harbour/main.cpp
@@ -53,6 +53,7 @@ Q_IMPORT_PLUGIN(PhoneBotProfilePlugin)
 Q_IMPORT_PLUGIN(PhoneBotTimePlugin)
 Q_IMPORT_PLUGIN(PhoneBotConnmanPlugin)
 Q_IMPORT_PLUGIN(PhoneBotAmbiencePlugin)
+Q_IMPORT_PLUGIN(PhoneBotNotificationPlugin)
 
 static const char *REASON = "Cannot be created";
 

--- a/src/plugins/notification/notification.pro
+++ b/src/plugins/notification/notification.pro
@@ -1,0 +1,14 @@
+TEMPLATE = lib
+TARGET = phonebotnotification
+QT = core dbus
+
+INCLUDEPATH += ../../lib/core \
+    ../../lib/meta \
+    ../../lib/nemomw
+
+CONFIG += plugin static
+
+HEADERS = notificationaction.h
+
+SOURCES = plugin.cpp \
+    notificationaction.cpp

--- a/src/plugins/notification/notificationaction.cpp
+++ b/src/plugins/notification/notificationaction.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2015 Zeta Sagittarii <zeta@sagittarii.fr>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * The names of its contributors may not be used to endorse or promote
+ *     products derived from this software without specific prior written
+ *     permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "notificationaction.h"
+#include <action_p.h>
+#include <choicemodel.h>
+//#include <QtDBus/QDBusConnection>
+//#include <QtDBus/QDBusInterface>
+#include <QtDBus>
+
+static const char *SUMMARY_KEY = "notificationSummary";
+static const char *TEXT_KEY = "notificationText";
+
+class NotificationActionPrivate: public ActionPrivate
+{
+public:
+    explicit NotificationActionPrivate(Action *q);
+
+    QString notificationText;
+    QString notificationSummary;
+
+private:
+};
+
+NotificationActionPrivate::NotificationActionPrivate(Action *q)
+    : ActionPrivate(q)
+{
+}
+
+NotificationAction::NotificationAction(QObject *parent) :
+    Action(*(new NotificationActionPrivate(this)), parent)
+{
+}
+
+NotificationAction::~NotificationAction()
+{
+}
+
+QString NotificationAction::notificationText() const
+{
+    Q_D(const NotificationAction);
+    return d->notificationText;
+}
+
+void NotificationAction::setNotificationText(const QString &notificationText)
+{
+    Q_D(NotificationAction);
+    if (d->notificationText != notificationText)
+    {
+        d->notificationText = notificationText;
+        emit notificationTextChanged();
+    }
+}
+
+QString NotificationAction::notificationSummary() const
+{
+    Q_D(const NotificationAction);
+    return d->notificationSummary;
+}
+
+void NotificationAction::setNotificationSummary(const QString &notificationSummary)
+{
+    Q_D(NotificationAction);
+    if (d->notificationSummary != notificationSummary)
+    {
+        d->notificationSummary = notificationSummary;
+        emit notificationSummaryChanged();
+    }
+}
+
+
+bool NotificationAction::execute(Rule *rule)
+{
+    Q_D(NotificationAction);
+    Q_UNUSED(rule);
+
+    sendFreedesktopNotification(d->notificationSummary, d->notificationText);
+
+    return true;
+}
+
+
+void NotificationAction::sendFreedesktopNotification(QString summary,
+                                                   QString text)
+{
+    qDebug() << __FUNCTION__ << summary << text;
+
+    QDBusInterface* dbusNotificationInterface =
+            new QDBusInterface("org.freedesktop.Notifications",
+                               "/org/freedesktop/Notifications",
+                               "org.freedesktop.Notifications",
+                               QDBusConnection::sessionBus(),
+                               this);
+
+    if (!dbusNotificationInterface->isValid())
+    {
+        qDebug() << "Unable to to connect to org.freedesktop.Notifications dbus service.";
+        dbusNotificationInterface = NULL;
+    }
+
+    if (dbusNotificationInterface && dbusNotificationInterface->isValid())
+    {
+        QString appName = "PhoneBot";
+
+        /// \note see https://developer.gnome.org/notification-spec/
+        QList<QVariant> args;
+        args.append(appName); // Application Name
+        args.append(0U); // Replaces ID (0U)
+        //args.append(QString("/usr/share/icons/hicolor/86x86/apps/harbour-phonebot.png")); // Notification Icon
+        args.append(QString("")); // Notification Icon
+        args.append(summary); // Summary
+        args.append(text); // Body
+        args.append(QStringList()); // Actions
+
+        QVariantMap hints;
+        // for hints to make icon, see
+        // https://dev.visucore.com/bitcoin/doxygen/notificator_8cpp_source.html
+        args.append(hints);
+        args.append(0);
+
+        qDebug() << args;
+
+        QDBusMessage msg = dbusNotificationInterface->callWithArgumentList(QDBus::NoBlock,
+                                                        "Notify", args);
+        qDebug() << "Call returned : " << msg;
+    }
+}
+
+
+NotificationActionMeta::NotificationActionMeta(QObject *parent)
+    : AbstractMetaData(parent)
+{
+}
+
+QString NotificationActionMeta::name() const
+{
+    return tr("Notification");
+}
+
+QString NotificationActionMeta::description() const
+{
+    return tr("This action allows to show a notification when triggered.");
+}
+
+QString NotificationActionMeta::summary(const QVariantMap &properties) const
+{
+
+    return properties.value(SUMMARY_KEY).toString() + " / " + properties.value(TEXT_KEY).toString();
+}
+
+MetaProperty * NotificationActionMeta::getProperty(const QString &property, QObject *parent) const
+{
+    if (property == SUMMARY_KEY) {
+        return MetaProperty::create(property, MetaProperty::String, tr("Notification Summary"), parent);
+    }
+    if (property == TEXT_KEY) {
+        return MetaProperty::create(property, MetaProperty::String, tr("Notification Text"), parent);
+    }
+    return 0;
+}
+

--- a/src/plugins/notification/notificationaction.h
+++ b/src/plugins/notification/notificationaction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Lucien XU <sfietkonstantin@free.fr>
+ * Copyright (C) 2015 Zeta Sagittarii <zeta@sagittarii.fr>
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -29,28 +29,52 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-#include <QtCore/QCoreApplication>
-#include <QtCore/QtPlugin>
-#include "enginemanager.h"
+#ifndef AMBIANCEACTION_H
+#define AMBIANCEACTION_H
 
-Q_IMPORT_PLUGIN(PhoneBotDebugPlugin)
-Q_IMPORT_PLUGIN(PhoneBotProfilePlugin)
-Q_IMPORT_PLUGIN(PhoneBotTimePlugin)
-Q_IMPORT_PLUGIN(PhoneBotConnmanPlugin)
-Q_IMPORT_PLUGIN(PhoneBotAmbiencePlugin)
-Q_IMPORT_PLUGIN(PhoneBotNotificationPlugin)
+#include <action.h>
+#include <abstractmetadata.h>
 
-
-int main(int argc, char **argv)
+class NotificationActionPrivate;
+class NotificationActionMeta;
+class NotificationAction : public Action
 {
-    QCoreApplication app (argc, argv);
-    app.setOrganizationName("phonebot");
-    app.setApplicationName("phonebotd");
+    Q_OBJECT
+    Q_PROPERTY(QString notificationSummary READ notificationSummary WRITE setNotificationSummary NOTIFY notificationSummaryChanged)
+    Q_PROPERTY(QString notificationText READ notificationText WRITE setNotificationText NOTIFY notificationTextChanged)
+    PHONEBOT_METADATA(NotificationActionMeta)
+//    PHONEBOT_NO_METADATA
 
-    EngineManager manager;
-    manager.reloadEngine();
+public:
+    explicit NotificationAction(QObject *parent = 0);
+    virtual ~NotificationAction();
+    QString notificationText() const;
+    void setNotificationText(const QString &notificationText);
+    QString notificationSummary() const;
+    void setNotificationSummary(const QString &notificationSummary);
+    bool execute(Rule *rule);
 
-    QObject::connect(&app, &QCoreApplication::aboutToQuit, &manager, &EngineManager::stop);
+Q_SIGNALS:
+    void notificationTextChanged();
+    void notificationSummaryChanged();
 
-    return app.exec();
-}
+private:
+    Q_DECLARE_PRIVATE(NotificationAction)
+    void sendFreedesktopNotification(QString summary, QString text);
+};
+
+
+class NotificationActionMeta: public AbstractMetaData
+{
+    Q_OBJECT
+public:
+    Q_INVOKABLE explicit NotificationActionMeta(QObject * parent = 0);
+    QString name() const;
+    QString description() const;
+    QString summary(const QVariantMap &properties) const;
+protected:
+    MetaProperty * getProperty(const QString &property, QObject *parent = 0) const;
+};
+
+
+#endif // AMBIANCEACTION_H

--- a/src/plugins/notification/plugin.cpp
+++ b/src/plugins/notification/plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Lucien XU <sfietkonstantin@free.fr>
+ * Copyright (C) 2015 Zeta Sagittarii <zeta@sagittarii.fr>
  *
  * You may use this file under the terms of the BSD license as follows:
  *
@@ -29,28 +29,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
  */
 
-#include <QtCore/QCoreApplication>
-#include <QtCore/QtPlugin>
-#include "enginemanager.h"
+#include <phonebotextensionplugin.h>
+#include <QtQml/qqml.h>
+#include "notificationaction.h"
 
-Q_IMPORT_PLUGIN(PhoneBotDebugPlugin)
-Q_IMPORT_PLUGIN(PhoneBotProfilePlugin)
-Q_IMPORT_PLUGIN(PhoneBotTimePlugin)
-Q_IMPORT_PLUGIN(PhoneBotConnmanPlugin)
-Q_IMPORT_PLUGIN(PhoneBotAmbiencePlugin)
-Q_IMPORT_PLUGIN(PhoneBotNotificationPlugin)
-
-
-int main(int argc, char **argv)
+class PhoneBotNotificationPlugin: public PhoneBotExtensionPlugin
 {
-    QCoreApplication app (argc, argv);
-    app.setOrganizationName("phonebot");
-    app.setApplicationName("phonebotd");
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.SfietKonstantin.phonebot.PhoneBotExtensionInterface")
+public:
+    void registerTypes()
+    {
+        qmlRegisterType<NotificationAction>("org.SfietKonstantin.phonebot.notification", 1, 0, "NotificationAction");
+        qRegisterMetaType<NotificationActionMeta *>();
+    }
+};
 
-    EngineManager manager;
-    manager.reloadEngine();
-
-    QObject::connect(&app, &QCoreApplication::aboutToQuit, &manager, &EngineManager::stop);
-
-    return app.exec();
-}
+#include "plugin.moc"

--- a/src/plugins/plugins.pro
+++ b/src/plugins/plugins.pro
@@ -1,2 +1,2 @@
 TEMPLATE = subdirs
-SUBDIRS = debug profile time connman ambience
+SUBDIRS = debug profile time connman ambience notification


### PR DESCRIPTION
Hi SfietKonstantin,

Here is the notification plugin, done through DBus (as it was the only way I found before talking with you). 
As you noticed, it would be better to get it working with libnotify instead, but I would need some time to dig in that. 

So do as you prefer:
- accept it as it (it already works for me), and we'll upgrade it later on
- refuse it for now and I'll upgrade it to libnotify when having some time and update the PR (not this week, I am starting to have qofono working here)

And obviously, don't hesitate to comment on all the ugly things I may have done there, like last time. I must confess I did not yet took the time to read it to check for typos or mistakes.

Thanks !
